### PR TITLE
Set `$HOME` environment variable in `rbenv_execute`

### DIFF
--- a/providers/execute.rb
+++ b/providers/execute.rb
@@ -5,11 +5,16 @@
 # Author:: Jamie Winsor (<jamie@vialstudios.com>)
 #
 
+require 'etc'
+
 include Chef::Mixin::Rbenv
 
 def load_current_resource
+  @user                         = new_resource.user || Etc.getlogin
+  @home                         = Etc.getpwnam(@user).dir
   @path                         = [ rbenv_shims_path, rbenv_bin_path ] + new_resource.path + system_path
   @environment                  = new_resource.environment
+  @environment["HOME"]          = @home
   @environment["PATH"]          = @path.join(":")
   @environment["RBENV_ROOT"]    = rbenv_root_path
   @environment.delete("RBENV_VERSION") if !new_resource.ruby_version


### PR DESCRIPTION
Bundler 1.12.0 changed default behaviour and tries to write its cache in `$HOME`, but `rbenv_execute` didn't explicitly set that, so in most cases it was set to `/root` or `/home/kitchen`.

This diff properly sets `$HOME` to the home directory of the user passed as parameter to `rbenv_execute`.