### PR TITLE
Add ability to retry when a command fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,19 @@
-.vagrant
-Berksfile.lock
-Gemfile.lock
 *~
-*#
-.#*
-\#*#
-.*.sw[a-z]
-*.un~
+*.bak
+*.sw*
+*.lock
+vendor
+.vagrant
 /cookbooks
-.kitchen
+encrypted_data_bag_secret
+
+# Bundler
+bin/*
+.bundle/*
+
+# Kitchen
+.kitchen/
+.kitchen.local.yml
+
+# OSX
+.DS_Store

--- a/providers/execute.rb
+++ b/providers/execute.rb
@@ -32,6 +32,8 @@ action :run do
     environment new_resource.environment
     group       new_resource.group
     live_stream new_resource.live_stream
+    retries     new_resource.retries
+    retry_delay new_resource.retry_delay
     returns     new_resource.returns
     timeout     new_resource.timeout
     user        new_resource.user

--- a/resources/execute.rb
+++ b/resources/execute.rb
@@ -15,6 +15,8 @@ attribute :environment, kind_of: Hash, default: Hash.new
 attribute :group, kind_of: [String, Integer]
 attribute :live_stream, kind_of: [TrueClass, FalseClass], default: false
 attribute :path, kind_of: Array, default: Array.new
+attribute :retries, kind_of: Integer
+attribute :retry_delay, kind_of: Integer
 attribute :returns, kind_of: [Integer, Array]
 attribute :timeout, kind_of: Integer
 attribute :umask, kind_of: [String, Integer]


### PR DESCRIPTION
Adds support for the `retries` and `retry_delay` attributes supported by the `execute` resource in Chef.

Also update the `.gitignore` file while at it.