### PR TITLE
Version 1.12.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       "Riot Games"
 maintainer_email "jamie@vialstudios.com"
 license          "Apache 2.0"
 description      "Installs and configures rbenv"
-version          "1.11.0"
+version          "1.12.0"
 
 recipe "rbenv", "Installs and configures rbenv"
 recipe "rbenv::ruby_build", "Installs and configures ruby_build"


### PR DESCRIPTION
- Fix `rbenv_gem` on Ruby 2.6+ (#15)